### PR TITLE
[# 167518830] Enable default auth in TP for development

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+1.3
+===
+ - Unmark authorized_for? as a view helper method
+
 1.2
 ===
  - introduce Authorization module

--- a/lib/grnds/sso/authorization.rb
+++ b/lib/grnds/sso/authorization.rb
@@ -3,10 +3,6 @@ module Grnds
     module Authorization
       extend ActiveSupport::Concern
 
-      included do
-        helper_method :authorized_for?
-      end
-
       def authorized_for?(request, roles)
         AuthorizationConstraint.new(roles).matches?(request)
       end

--- a/lib/grnds/sso/version.rb
+++ b/lib/grnds/sso/version.rb
@@ -1,5 +1,5 @@
 module Grnds
   module Sso
-    VERSION = '1.2'
+    VERSION = '1.3'
   end
 end


### PR DESCRIPTION
Enable default auth in TP for development.

This is only required because Grape doesn't play nicely with `helper_method`. (Also, this method isn't being used in any view helpers, so not needed).

[Tracker #167518830](https://www.pivotaltracker.com/story/show/167518830)