### PR TITLE
DP-358 Automatically create Jira tickets for dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "07:00"
+    open-pull-requests-limit: 10

--- a/.github/workflows/dependabot_jira.yml
+++ b/.github/workflows/dependabot_jira.yml
@@ -1,0 +1,32 @@
+name: Dependabot Jira
+
+on:
+  pull_request:
+    types:
+      - opened
+    branches:
+      - master
+
+jobs:
+  create_jira:
+    name: Dependabot Jira
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+    - name: Login to Jira
+      uses: atlassian/gajira-login@v2.0.0
+      env:
+        JIRA_BASE_URL: ${{ secrets.SERVICES_PLATFORM_JIRA_URL }}
+        JIRA_USER_EMAIL: ${{ secrets.SERVICES_PLATFORM_JIRA_EMAIL }}
+        JIRA_API_TOKEN: ${{ secrets.SERVICES_PLATFORM_JIRA_API_TOKEN }}
+
+    - name: Create Jira Issue
+      id: create
+      uses: atlassian/gajira-create@v2.0.1
+      with:
+        project: DP
+        issuetype: Tech Debt
+        summary: |
+          [${{ github.event.repository.name }}] ${{ github.event.pull_request.title }}
+        description: |
+          [ServicesPlatformDependabot] ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
SP owns many repos that need to be kept up-to-date. We use (or should use) dependabot to track updates. When dependabot opens up a pull request, it should also file a ticket in Jira for an engineer to review. 
https://doctorondemand.atlassian.net/browse/DP-358