### PR TITLE
Update grnds-auth0 version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,16 @@
 GIT
   remote: git@github.com:ConsultingMD/auth0.git
-  revision: d853b0695e93117d8ea8f52c4ce82ccdc715be22
+  revision: eeb6654868efd62bddb9c0bcf5764ec878f7a6c9
   branch: master
   specs:
-    grnds-auth0 (1.1.0)
+    grnds-auth0 (3.2.0)
+      auth0 (~> 4.8.0)
       typhoeus (>= 1.3.1)
 
 PATH
   remote: .
   specs:
-    grnds-sso (2.1.0)
+    grnds-sso (2.2.0)
       grnds-auth0
 
 GEM
@@ -57,16 +58,23 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     arel (9.0.0)
+    auth0 (4.8.0)
+      rest-client (~> 2.0)
     builder (3.2.3)
     concurrent-ruby (1.1.5)
     crass (1.0.4)
     diff-lcs (1.3)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
     erubi (1.8.0)
     ethon (0.12.0)
       ffi (>= 1.3.0)
     ffi (1.11.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    http-accept (1.7.0)
+    http-cookie (1.0.5)
+      domain_name (~> 0.5)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     loofah (2.2.3)
@@ -77,10 +85,16 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (0.9.2)
-    mimemagic (0.3.3)
+    mime-types (3.4.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2022.0105)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
+    netrc (0.11.0)
     nio4r (2.4.0)
     nokogiri (1.10.3)
       mini_portile2 (~> 2.4.0)
@@ -112,6 +126,11 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (12.3.3)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -140,6 +159,9 @@ GEM
       ethon (>= 0.9.0)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.8.2)
     websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
@@ -155,4 +177,4 @@ DEPENDENCIES
   rspec_junit_formatter (= 0.4.1)
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/lib/grnds/sso/version.rb
+++ b/lib/grnds/sso/version.rb
@@ -1,5 +1,5 @@
 module Grnds
   module Sso
-    VERSION = '2.1.0'.freeze
+    VERSION = '2.2.0'.freeze
   end
 end


### PR DESCRIPTION
Many services interact with grnds-auth0 through this gem. Updating this gem with the latest grnds-auth0 version so folks using grnds-sso are up-to-date.