### PR TITLE
Update grnds-auth0 to 3.4.0

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ConsultingMD/developer-platform

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,16 @@
 GIT
   remote: git@github.com:ConsultingMD/auth0.git
-  revision: 926231f89f6a2553e39ea20ea165a8d0fb82bcf5
+  revision: ff4ca50aae5b83795a6e537e1745d89b00b3c85c
   branch: master
   specs:
-    grnds-auth0 (3.3.0)
+    grnds-auth0 (3.4.0)
       auth0 (~> 4.8.0)
       typhoeus (>= 1.3.1)
 
 PATH
   remote: .
   specs:
-    grnds-sso (2.3.0)
+    grnds-sso (2.4.0)
       grnds-auth0
 
 GEM

--- a/lib/grnds/sso/version.rb
+++ b/lib/grnds/sso/version.rb
@@ -1,5 +1,5 @@
 module Grnds
   module Sso
-    VERSION = '2.3.0'.freeze
+    VERSION = '2.4.0'.freeze
   end
 end


### PR DESCRIPTION
This commit updates grnds-auth0 to version 3.4.0 so that this gem can take advantage of multi-namespace claim evaluation.