### PR TITLE
Publish gem to private gemfury repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 
 version: 2.1
 
- workflows:
+workflows:
   build:
     jobs:
       - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,23 @@
-# Ruby CircleCI 2.0 configuration file
-#
-# Check https://circleci.com/docs/2.0/language-ruby/ for more details
-#
-version: 2
+# Ruby CircleCI 2.1 configuration file
+
+version: 2.1
+
+ workflows:
+  build:
+    jobs:
+      - build
+      - publish:
+          requires:
+            - build
+          context:
+            - dod-pypi
+          filters:
+            # only publish gem after cutting tag
+            tags:
+              only: /.*/
+            branches:
+              ignore: /.*/
+
 jobs:
   build:
     docker:
@@ -49,3 +64,11 @@ jobs:
       - store_artifacts:
           path: /tmp/test-results
           destination: test-results
+  publish:
+    docker:
+      - image: circleci/ruby:2.4
+    steps:
+      - checkout
+      - run:
+          name: Build and publish gem to gemfury
+          command: ./.circleci/publish.sh

--- a/.circleci/publish.sh
+++ b/.circleci/publish.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ -z "$GEMFURY_PUSH_TOKEN" ]; then
+    echo 'Environment variable GEMFURY_PUSH_TOKEN must be specified. Aborting.'
+    exit 1
+fi
+
+for file in `ls *.gemspec`; do
+    gem build $file
+done
+
+# Publish to Gemfury (based on: https://gemfury.com/help/upload-packages/#cURL)
+for file in `ls *.gem`; do
+    echo "Publishing new package version: ${file}"
+    curl --fail -F package=@${file} https://${GEMFURY_PUSH_TOKEN}@push.fury.io/doctorondemand/
+done

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Releases happen in CircleCI when a tag is pushed to the repository.
 
 To create a release, you will need to do the following:
 
-1. Change the version in `lib/grnds/reporting/version.rb` to the new version and create a PR with the change.
+1. Change the version in `lib/grnds/sso/version.rb` to the new version and create a PR with the change.
 1. Once the PR is merged, switch to the master branch and `git pull`.
 1. `git tag <version from version.rb>`
 1. `git push origin --tags`

--- a/README.md
+++ b/README.md
@@ -49,3 +49,16 @@ config.secret_token = ENV['RAILS_COOKIE_SECRET'] || copy_it_yourself_from_tim_or
 bundle install
 bundle exec rspec
 ```
+
+## How to Create a Release
+
+Releases happen in CircleCI when a tag is pushed to the repository.
+
+To create a release, you will need to do the following:
+
+1. Change the version in `lib/grnds/reporting/version.rb` to the new version and create a PR with the change.
+1. Once the PR is merged, switch to the master branch and `git pull`.
+1. `git tag <version from version.rb>`
+1. `git push origin --tags`
+
+CircleCI will see the tag push, build, and release a new version of the library.


### PR DESCRIPTION
Currently our private gems are installed from github using git, and this requires an additional setup step that involves creating a github token.

We’re planning to start installing our private gems from gemfury (a private gem repository) to avoid creating github tokens.

This PR starts publishing this repo's gem to gemfury to allow for this.

More details in this doc: https://docs.google.com/document/d/1jRcN13jN6Ws4kPj79087wK4HrJwnjeTES5etebcuDH0/edit