### PR TITLE
[DT-108] Default to gem.fury.io for private gems in the Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 # gem's dependencies specified in `./grnds-sso.gemspec`
 gemspec
 
-gem 'grnds-auth0', source: 'https://gems.includedhealth.com/doctorondemand/'
+gem 'grnds-auth0', source: 'https://gem.fury.io/doctorondemand/'
 
 group :test do
   gem 'rails', '5.2.0', require: %w(action_controller rails)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ PATH
 
 GEM
   remote: https://rubygems.org/
-  remote: https://gems.includedhealth.com/doctorondemand/
+  remote: https://gem.fury.io/doctorondemand/
   specs:
     actioncable (5.2.0)
       actionpack (= 5.2.0)


### PR DESCRIPTION
Recently we learned that dependabot doesn't allow configuring mirrors for gems, and we're currently relying on this functionality to switch from using the internal gem proxy to the external gem.fury.io url.

This PR switches the default functionality to use gem.fury.io by default instead (to fix dependabot).